### PR TITLE
Fixes issue #2: Code generator creates unused functions.

### DIFF
--- a/example/ts_client/service.ts
+++ b/example/ts_client/service.ts
@@ -18,15 +18,6 @@ interface HatJSON {
     
 }
 
-const HatToJSON = (m: Hat): HatJSON => {
-    return {
-        size: m.size,
-        color: m.color,
-        name: m.name,
-        created_on: m.createdOn.toISOString(),
-        
-    };
-};
 
 const JSONToHat = (m: HatJSON): Hat => {
     return {
@@ -48,14 +39,8 @@ interface SizeJSON {
     
 }
 
-const SizeToJSON = (m: Size): SizeJSON => {
-    return {
-        inches: m.inches,
-        
-    };
-};
 
-const JSONToSize = (m: SizeJSON): Size => {
+const SizeToJSON = (m: Size): SizeJSON => {
     return {
         inches: m.inches,
         


### PR DESCRIPTION
CreateClientAPI would always generate marshal and unmarshal methods for Messages, even if they were never referenced as parameters or return values in rpc Service methods.  The CanMarshal and CanUnmarshal flags were added so that the template can only output these conversion functions for Messages that need them, eliminating the unused functions.