### PR TITLE
Fix parse repeated message

### DIFF
--- a/generator/client.go
+++ b/generator/client.go
@@ -31,7 +31,7 @@ interface {{.Name}}JSON {
 
 {{if .CanMarshal}}
 const {{.Name}}ToJSON = (m: {{.Name}}): {{.Name}}JSON => {
-	return {
+    return {
         {{range .Fields -}}
         {{.JSONName}}: {{stringify .}},
         {{end}}
@@ -54,7 +54,7 @@ const JSONTo{{.Name}} = (m: {{.Name}} | {{.Name}}JSON): {{.Name}} => {
 
 {{range .Services}}
 export interface {{.Name}} {
-	{{- range .Methods}}
+    {{- range .Methods}}
     {{.Name}}: ({{.InputArg}}: {{.InputType}}) => Promise<{{.OutputType}}>;
     {{end}}
 }
@@ -62,28 +62,28 @@ export interface {{.Name}} {
 export class Default{{.Name}} implements {{.Name}} {
     private hostname: string;
     private fetch: Fetch;
-	private writeCamelCase: boolean;
+    private writeCamelCase: boolean;
     private pathPrefix = "/twirp/{{.Package}}.{{.Name}}/";
 
     constructor(hostname: string, fetch: Fetch, writeCamelCase = false) {
         this.hostname = hostname;
         this.fetch = fetch;
-		this.writeCamelCase = writeCamelCase;
+        this.writeCamelCase = writeCamelCase;
     }
 
     {{- range .Methods}}
     {{.Name}}({{.InputArg}}: {{.InputType}}): Promise<{{.OutputType}}> {
         const url = this.hostname + this.pathPrefix + "{{.Path}}";
-		let body: {{.InputType}} | {{.InputType}}JSON = {{.InputArg}};
-		if(!this.writeCamelCase){
-			body = {{.InputType}}ToJSON({{.InputArg}});
-		}
+        let body: {{.InputType}} | {{.InputType}}JSON = {{.InputArg}};
+        if (!this.writeCamelCase) {
+            body = {{.InputType}}ToJSON({{.InputArg}});
+        }
         return this.fetch(createTwirpRequest(url, body)).then((resp) => {
- 			if (!resp.ok) {
+            if (!resp.ok) {
                 return throwTwirpError(resp);
             }
 
-			return resp.json().then(JSONTo{{.OutputType}});
+            return resp.json().then(JSONTo{{.OutputType}});
         });
     }
     {{end}}

--- a/generator/client_test.go
+++ b/generator/client_test.go
@@ -1,6 +1,8 @@
 package generator
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestAPIContext_ApplyMarshalFlags(t *testing.T) {
 	nested := &Model{
@@ -52,5 +54,101 @@ func TestAPIContext_ApplyMarshalFlags(t *testing.T) {
 
 	if nested.CanMarshal != true {
 		t.Errorf("expected nested.CanMarshal to be true since it is a field in Bar")
+	}
+}
+
+func Test_parse(t *testing.T) {
+	type args struct {
+		f         ModelField
+		modelName string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			// Example proto:
+			// message GetClientsResponse {
+			//   repeated google.protobuf.Timestamp dates = 1;
+			// }
+			name: "repeated date field with no snake case",
+			args: args{
+				f: ModelField{
+					Name:       "dates",
+					Type:       "Date[]",
+					JSONName:   "dates",
+					JSONType:   "string[]",
+					IsRepeated: true,
+					IsMessage:  false,
+				},
+				modelName: "GetClientsResponse",
+			},
+			want: "(m.dates as (Date | string)[]).map((n) => new Date(n))",
+		},
+		{
+			// Example proto:
+			// message GetClientsResponse {
+			//   repeated google.protobuf.Timestamp special_dates = 1;
+			// }
+			name: "repeated date field with snake case",
+			args: args{
+				f: ModelField{
+					Name:       "special_dates",
+					Type:       "Date[]",
+					JSONName:   "specialDates",
+					JSONType:   "string[]",
+					IsRepeated: true,
+					IsMessage:  false,
+				},
+				modelName: "GetClientsResponse",
+			},
+			want: "((((m as GetClientsResponse).special_dates) ? (m as GetClientsResponse).special_dates : (m as GetClientsResponseJSON).specialDates) as (Date | string)[]).map((n) => new Date(n))",
+		},
+		{
+			// Example proto:
+			// message GetClientsResponse {
+			//   repeated Client clients = 1;
+			// }
+			name: "repeated message field with no snake case",
+			args: args{
+				f: ModelField{
+					Name:       "clients",
+					Type:       "Client[]",
+					JSONName:   "clients",
+					JSONType:   "ClientJSON[]",
+					IsRepeated: true,
+					IsMessage:  true,
+				},
+				modelName: "GetClientsResponse",
+			},
+			want: "(m.clients as (Client | ClientJSON)[]).map(JSONToClient)",
+		},
+		{
+			// Example proto:
+			// message GetClientsResponse {
+			//   repeated Client special_clients = 1;
+			// }
+			name: "repeated message field with snake case",
+			args: args{
+				f: ModelField{
+					Name:       "special_clients",
+					Type:       "Client[]",
+					JSONName:   "specialClients",
+					JSONType:   "ClientJSON[]",
+					IsRepeated: true,
+					IsMessage:  true,
+				},
+				modelName: "GetClientsResponse",
+			},
+			want: "((((m as GetClientsResponse).special_clients) ? (m as GetClientsResponse).special_clients : (m as GetClientsResponseJSON).specialClients) as (Client | ClientJSON)[]).map(JSONToClient)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parse(tt.args.f, tt.args.modelName); got != tt.want {
+				t.Errorf("parse() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Branched off #16 so includes that commit.

Should fix #15. Added a test to verify. Note: didn't add other tests to the table tests for testing all parts of `parse`—only added the previously failing case for repeated messages.

@keynan does this look ok to you?

Note that I changed a couple of instances to just use `strings.Trim()` to remove the `[]`—feels safer to me. Also changed `strings.Compare` to just use `==` per Go's recommendation.