### PR TITLE
Twirp v6 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,14 @@ This is different behavior than the twirp Go plugin, which places the files rela
 This decision is intentional, since only client code destination is likely somewhere different
 than the server code.
 
+### Generating Code for Twirp v6
+
+By default code is generated that supports the twirp v5 spec. If you want to use the the v6 prerelease specify the 
+version using protoc params.
+
+    protoc --twirp_typescript_out=version=v6:<path-to-project> <path-to-proto-file>
+    
+The relevant change here is the routing path, which now starts with the proto package instead of "twirp/".
+
 * [Minimal JSON Client Usage](doc/minimal.md)
 * [Protobuf.js Client Usage](doc/protobufjs.md)

--- a/doc/minimal.md
+++ b/doc/minimal.md
@@ -1,5 +1,11 @@
 # Twirp Minimal JSON Client
 
+If you want to just use JSON over the wire instead of protobuf, use this client. It produces a very compact module
+that will add minimal overhead to a project.
+
+The caveat is that it does not have full support for the protobuf spec. If you need full support 
+(nested messages, Any type, etc.) please use the protobuf.js variant.
+
 ## Usage
 
     go get -u go.larrymyers.com/protoc-gen-twirp_typescript

--- a/doc/protobufjs.md
+++ b/doc/protobufjs.md
@@ -1,5 +1,13 @@
 # Twirp Protobuf.js Client
 
+This generator creates an RPC implementation for twirp that can be used with [protobuf.js](https://github.com/dcodeIO/ProtoBuf.js).
+
+See: https://github.com/dcodeIO/ProtoBuf.js/#using-services
+
+The `pbjs` and `pbts` commands provided by protobuf.js still need to be used to generate the protobuf client.
+
+There is a provided [example](example/pbjs_client) that shows how to use the generated code.
+
 ## Generate Protobuf.js Code
 
     pbjs -t static-module -w commonjs -o <path-to-project>/service.pb.js <path-to-proto-file>

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -30,11 +32,20 @@ type Generator interface {
 	Generate(d *descriptor.FileDescriptorProto) ([]*plugin.CodeGeneratorResponse_File, error)
 }
 
-func NewGenerator(p map[string]string) Generator {
-	lib, ok := p["library"]
-	if ok && lib == "pbjs" {
-		return pbjs.NewGenerator()
+func NewGenerator(p map[string]string) (Generator, error) {
+	version, ok := p["version"]
+	if !ok {
+		version = "v5"
 	}
 
-	return minimal.NewGenerator(p)
+	if version != "v5" && version != "v6" {
+		return nil, errors.New(fmt.Sprintf("version is %s, must be v5 or v6", version))
+	}
+
+	lib, ok := p["library"]
+	if ok && lib == "pbjs" {
+		return pbjs.NewGenerator(version), nil
+	}
+
+	return minimal.NewGenerator(version, p), nil
 }

--- a/main.go
+++ b/main.go
@@ -36,7 +36,12 @@ func readRequest(r io.Reader) *plugin.CodeGeneratorRequest {
 func generate(in *plugin.CodeGeneratorRequest) *plugin.CodeGeneratorResponse {
 	resp := &plugin.CodeGeneratorResponse{}
 	params := generator.GetParameters(in)
-	gen := generator.NewGenerator(params)
+
+	gen, err := generator.NewGenerator(params)
+	if err != nil {
+		resp.Error = proto.String(err.Error())
+		return resp
+	}
 
 	for _, f := range in.GetProtoFile() {
 		files, err := gen.Generate(f)


### PR DESCRIPTION
Both minimal and pbjs generators support v5 and v6 routing.

The twirp version can be specified via protoc param args.  Both example projects have been tested
with the v6_prerelease branch for the twirp project and work as expected.

Documentation has been updated to show to use this project with twirp v6.

This fixes issue #19.