### PR TITLE
pbjs: don't generate anything if there are no svcs

### DIFF
--- a/generator/pbjs/generator.go
+++ b/generator/pbjs/generator.go
@@ -73,6 +73,11 @@ func (g *Generator) Generate(d *descriptor.FileDescriptorProto) ([]*plugin.CodeG
 		return []*plugin.CodeGeneratorResponse_File{}, nil
 	}
 
+	// If there are no services, there's nothing to generate for this file.
+	if len(d.Service) == 0 {
+		return []*plugin.CodeGeneratorResponse_File{}, nil
+	}
+
 	twirpPrefix := "/twirp"
 	if g.twirpVersion == "v6" {
 		twirpPrefix = ""

--- a/generator/pbjs/generator_test.go
+++ b/generator/pbjs/generator_test.go
@@ -1,0 +1,50 @@
+package pbjs
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
+)
+
+func TestGenerate(t *testing.T) {
+	tests := []struct {
+		name    string
+		d       *descriptor.FileDescriptorProto
+		want    []*plugin.CodeGeneratorResponse_File
+		wantErr bool
+	}{
+		{
+			name: "don't generate anything for timestamp.proto",
+			d: &descriptor.FileDescriptorProto{
+				Name: proto.String("google/protobuf/timestamp.proto"),
+			},
+			want:    []*plugin.CodeGeneratorResponse_File{},
+			wantErr: false,
+		},
+		{
+			name: "don't generate anything if there are no services",
+			d: &descriptor.FileDescriptorProto{
+				Name:    proto.String("message.proto"),
+				Service: []*descriptor.ServiceDescriptorProto{},
+			},
+			want:    []*plugin.CodeGeneratorResponse_File{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &Generator{}
+			got, err := g.Generate(tt.d)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Generator.Generate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Generator.Generate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The pbjs generator only generates code for services. If the proto file
contains no services, there's no need to generate a mostly-empty JS
file.

Also add a test for ensuring that google/protobuf/timestamp.proto does
not generate anything.