### PR TITLE
Fix missing argument to NewAPIContext in test

### DIFF
--- a/generator/minimal/client_test.go
+++ b/generator/minimal/client_test.go
@@ -39,7 +39,7 @@ func TestAPIContext_ApplyMarshalFlags(t *testing.T) {
 		Methods: []ServiceMethod{call},
 	}
 
-	ctx := NewAPIContext()
+	ctx := NewAPIContext("")
 
 	ctx.AddModel(nested)
 	ctx.AddModel(bar)


### PR DESCRIPTION
@larrymyers the tests were failing from a previous change where twirp version support was added. Might be a good time for you to add a CI tool in here like Travis or Circle? Not sure if I can do it since I'm not a repository admin.