### PR TITLE
Fix parsing of repeated nested types

### DIFF
--- a/generator/minimal/client.go
+++ b/generator/minimal/client.go
@@ -149,6 +149,15 @@ func (ctx *APIContext) AddModel(m *Model) {
 	ctx.modelLookup[m.Name] = m
 }
 
+func getBaseType(f ModelField) string {
+	baseType := f.Type
+	if f.IsRepeated {
+		baseType = strings.Trim(baseType, "[]")
+	}
+
+	return baseType
+}
+
 // ApplyMarshalFlags will inspect the CanMarshal and CanUnmarshal flags for models where
 // the flags are enabled and recursively set the same values on all the models that are field types.
 func (ctx *APIContext) ApplyMarshalFlags() {
@@ -159,10 +168,7 @@ func (ctx *APIContext) ApplyMarshalFlags() {
 				continue
 			}
 
-			baseType := f.Type
-			if f.IsRepeated {
-				baseType = strings.Trim(baseType, "[]")
-			}
+			baseType := getBaseType(f)
 
 			if m.CanMarshal {
 				ctx.enableMarshal(ctx.modelLookup[baseType])
@@ -187,7 +193,10 @@ func (ctx *APIContext) enableMarshal(m *Model) {
 		if !f.IsMessage || f.Type == "Date" {
 			continue
 		}
-		mm, ok := ctx.modelLookup[f.Type]
+
+		baseType := getBaseType(f)
+
+		mm, ok := ctx.modelLookup[baseType]
 		if !ok {
 			log.Fatalf("could not find model of type %s for field %s", f.Type, f.Name)
 		}
@@ -203,7 +212,9 @@ func (ctx *APIContext) enableUnmarshal(m *Model) {
 		if !f.IsMessage || f.Type == "Date" {
 			continue
 		}
-		mm, ok := ctx.modelLookup[f.Type]
+		baseType := getBaseType(f)
+
+		mm, ok := ctx.modelLookup[baseType]
 		if !ok {
 			log.Fatalf("could not find model of type %s for field %s", f.Type, f.Name)
 		}

--- a/generator/minimal/client_test.go
+++ b/generator/minimal/client_test.go
@@ -39,7 +39,7 @@ func TestAPIContext_ApplyMarshalFlags(t *testing.T) {
 		Methods: []ServiceMethod{call},
 	}
 
-	ctx := NewAPIContext()
+	ctx := NewAPIContext("")
 
 	ctx.AddModel(nested)
 	ctx.AddModel(bar)


### PR DESCRIPTION
Fixes https://github.com/larrymyers/protoc-gen-twirp_typescript/issues/11

Thank for the excellent work on this package, @larrymyers!

It looks like some of the recursive funcs didn't trim the leading `[]`.

There was an issue running tests where a missing arg was breaking the build. There is a commit attached for that as well.

Thanks again!

