### PR TITLE
Fix unmarshalling of zero-length arrays.

### DIFF
--- a/generator/minimal/client.go
+++ b/generator/minimal/client.go
@@ -475,7 +475,7 @@ func parse(f ModelField, modelName string) string {
 		singularTSType := strings.Trim(f.Type, "[]")       // strip array brackets from type
 		singularJSONType := strings.Trim(f.JSONType, "[]") // strip array brackets from type
 
-		arrayField := fmt.Sprintf("(%s as (%s | %s)[])", field, singularTSType, singularJSONType)
+		arrayField := fmt.Sprintf("((%s as (%s | %s)[]) || [])", field, singularTSType, singularJSONType)
 
 		if f.Type == "Date[]" {
 			return fmt.Sprintf("%s.map((n) => new Date(n))", arrayField)
@@ -484,6 +484,8 @@ func parse(f ModelField, modelName string) string {
 		if f.IsMessage {
 			return fmt.Sprintf("%s.map(JSONTo%s)", arrayField, singularTSType)
 		}
+
+		return fmt.Sprintf("%s || []", field)
 	}
 
 	if f.Type == "Date" {


### PR DESCRIPTION
Ensure we fall back to a zero-length array in both the repeated primitive
field and repeated message field cases when said field is `undefined`.

Fixes #37.