### PR TITLE
allow axios options per service

### DIFF
--- a/generator/pbjs/generator.go
+++ b/generator/pbjs/generator.go
@@ -33,13 +33,16 @@ const getServiceMethodName = (fn: any): string => {
 {{range .Services}}
 export const {{.Name}}PathPrefix = '{{$twirpPrefix}}/{{.Package}}.{{.Name}}/';
 
-export const create{{.Name}} = (baseURL: string): {{.Package}}.{{.Name}} => {
-	const axios = Axios.create({
+export const create{{.Name}} = (baseURL: string, options = {}): {{.Package}}.{{.Name}} => {
+    const defaultOpts = {
         baseURL: baseURL + {{.Name}}PathPrefix,
         headers: {
           Accept: 'application/protobuf'
         }
-    });
+    };
+    const axiosOpts = { ...defaultOpts, ...options };
+    
+    const axios = Axios.create(axiosOpts);
 
     return {{.Package}}.{{.Name}}.create(createTwirpAdapter(axios, getServiceMethodName));
 };


### PR DESCRIPTION
This is the same change as https://github.com/larrymyers/protoc-gen-twirp_typescript/pull/39 but to `master`.  My hope is this PR will save you time.  I think the `version=v6` stuff works from `master` but I can't remember.  If so, close PR above and maybe delete the `twirp_v6_support` branch to avoid confusion.  Thanks!

Previously, the only way to configure the axios client used in twirp_typescript was to use [global defaults](https://github.com/axios/axios#global-axios-defaults).  This is not ideal, as axios is so common, its used pervasively throughout apps.  This PR implements a backwards compat change allowing you to optionally specify axios opts on a per service basis.  Some may not need this level of flexibility, but its an absolute requirement for my use case.