### PR TITLE
JSON Client: Header overrides, empty message, proto3 fields are optional

### DIFF
--- a/generator/minimal/client.go
+++ b/generator/minimal/client.go
@@ -336,7 +336,6 @@ func (g *Generator) Generate(d *descriptor.FileDescriptorProto) ([]*plugin.CodeG
 	clientAPI.Content = proto.String(b.String())
 
 	files = append(files, clientAPI)
-	files = append(files, RuntimeLibrary())
 
 	if pkgName, ok := g.params["package_name"]; ok {
 		idx, err := CreatePackageIndex(files)

--- a/generator/minimal/client.go
+++ b/generator/minimal/client.go
@@ -19,13 +19,13 @@ import {createTwirpRequest, throwTwirpError, Fetch} from './twirp';
 {{range .Models}}
 {{- if not .Primitive}}
 export interface {{.Name}} {
-    {{range .Fields -}}
+    {{- range .Fields}}
     {{.Name}}?: {{.Type}};
     {{- end}}
 }
 
 interface {{.Name}}JSON {
-    {{range .Fields -}}
+    {{- range .Fields}}
     {{.JSONName}}?: {{.JSONType}};
     {{- end}}
 }
@@ -34,7 +34,7 @@ interface {{.Name}}JSON {
 {{if .Fields}}
 const {{.Name}}ToJSON = (m: {{.Name}}): {{.Name}}JSON => {
     return {
-        {{range .Fields -}}
+        {{- range .Fields}}
         {{.JSONName}}: {{stringify .}},
         {{- end}}
     };
@@ -51,7 +51,7 @@ const {{.Name}}ToJSON = (_: {{.Name}}): {{.Name}}JSON => {
 const JSONTo{{.Name}} = (m: {{.Name}} | {{.Name}}JSON): {{.Name}} => {
     {{$Model := .Name -}}
     return {
-        {{range .Fields -}}
+        {{- range .Fields}}
         {{.Name}}: {{parse . $Model}},
         {{- end}}
     };

--- a/generator/minimal/client.go
+++ b/generator/minimal/client.go
@@ -20,13 +20,13 @@ import {createTwirpRequest, throwTwirpError, Fetch} from './twirp';
 {{- if not .Primitive}}
 export interface {{.Name}} {
     {{range .Fields -}}
-    {{.Name}}: {{.Type}};
+    {{.Name}}?: {{.Type}};
     {{end}}
 }
 
 interface {{.Name}}JSON {
     {{range .Fields -}}
-    {{.JSONName}}: {{.JSONType}};
+    {{.JSONName}}?: {{.JSONType}};
     {{end}}
 }
 

--- a/generator/minimal/client.go
+++ b/generator/minimal/client.go
@@ -48,6 +48,7 @@ const {{.Name}}ToJSON = (_: {{.Name}}): {{.Name}}JSON => {
 {{end -}}
 
 {{if .CanUnmarshal}}
+{{if .Fields}}
 const JSONTo{{.Name}} = (m: {{.Name}} | {{.Name}}JSON): {{.Name}} => {
     {{$Model := .Name -}}
     return {
@@ -56,6 +57,12 @@ const JSONTo{{.Name}} = (m: {{.Name}} | {{.Name}}JSON): {{.Name}} => {
         {{- end}}
     };
 };
+{{else -}}
+{{/* Handle the generic empty message */ -}}
+const JSONTo{{.Name}} = (_: {{.Name}} | {{.Name}}JSON): {{.Name}} => {
+    return {};
+};
+{{end}}
 {{end -}}
 
 {{end -}}

--- a/generator/minimal/client.go
+++ b/generator/minimal/client.go
@@ -31,6 +31,7 @@ interface {{.Name}}JSON {
 }
 
 {{if .CanMarshal}}
+{{if .Fields}}
 const {{.Name}}ToJSON = (m: {{.Name}}): {{.Name}}JSON => {
     return {
         {{range .Fields -}}
@@ -38,6 +39,12 @@ const {{.Name}}ToJSON = (m: {{.Name}}): {{.Name}}JSON => {
         {{end}}
     };
 };
+{{else -}}
+{{/* Handle the generic empty message */ -}}
+const {{.Name}}ToJSON = (_: {{.Name}}): {{.Name}}JSON => {
+    return {};
+};
+{{end}}
 {{end -}}
 
 {{if .CanUnmarshal}}
@@ -50,6 +57,7 @@ const JSONTo{{.Name}} = (m: {{.Name}} | {{.Name}}JSON): {{.Name}} => {
     };
 };
 {{end -}}
+
 {{end -}}
 {{end}}
 

--- a/generator/minimal/client.go
+++ b/generator/minimal/client.go
@@ -75,11 +75,13 @@ export class Default{{.Name}} implements {{.Name}} {
     private fetch: Fetch;
     private writeCamelCase: boolean;
     private pathPrefix = "{{$twirpPrefix}}/{{.Package}}.{{.Name}}/";
+    private headersOverride: HeadersInit;
 
-    constructor(hostname: string, fetch: Fetch, writeCamelCase = false) {
+    constructor(hostname: string, fetch: Fetch, writeCamelCase = false, headersOverride: HeadersInit = {}) {
         this.hostname = hostname;
         this.fetch = fetch;
         this.writeCamelCase = writeCamelCase;
+        this.headersOverride = headersOverride;
     }
 
     {{- range .Methods}}
@@ -89,7 +91,7 @@ export class Default{{.Name}} implements {{.Name}} {
         if (!this.writeCamelCase) {
             body = {{.InputType}}ToJSON({{.InputArg}});
         }
-        return this.fetch(createTwirpRequest(url, body)).then((resp) => {
+        return this.fetch(createTwirpRequest(url, body, this.headersOverride)).then((resp) => {
             if (!resp.ok) {
                 return throwTwirpError(resp);
             }

--- a/generator/minimal/client.go
+++ b/generator/minimal/client.go
@@ -21,13 +21,13 @@ import {createTwirpRequest, throwTwirpError, Fetch} from './twirp';
 export interface {{.Name}} {
     {{range .Fields -}}
     {{.Name}}?: {{.Type}};
-    {{end}}
+    {{- end}}
 }
 
 interface {{.Name}}JSON {
     {{range .Fields -}}
     {{.JSONName}}?: {{.JSONType}};
-    {{end}}
+    {{- end}}
 }
 
 {{if .CanMarshal}}
@@ -36,7 +36,7 @@ const {{.Name}}ToJSON = (m: {{.Name}}): {{.Name}}JSON => {
     return {
         {{range .Fields -}}
         {{.JSONName}}: {{stringify .}},
-        {{end}}
+        {{- end}}
     };
 };
 {{else -}}
@@ -49,11 +49,11 @@ const {{.Name}}ToJSON = (_: {{.Name}}): {{.Name}}JSON => {
 
 {{if .CanUnmarshal}}
 const JSONTo{{.Name}} = (m: {{.Name}} | {{.Name}}JSON): {{.Name}} => {
-    {{$Model := .Name}}
+    {{$Model := .Name -}}
     return {
         {{range .Fields -}}
         {{.Name}}: {{parse . $Model}},
-        {{end}}
+        {{- end}}
     };
 };
 {{end -}}

--- a/generator/minimal/twirp_common.go
+++ b/generator/minimal/twirp_common.go
@@ -29,12 +29,16 @@ export const throwTwirpError = (resp: Response) => {
     return resp.json().then((err: TwirpErrorJSON) => { throw new TwirpError(err); })
 };
 
-export const createTwirpRequest = (url: string, body: object): Request => {
-    return new Request(url, {
-        method: "POST",
-        headers: {
+export const createTwirpRequest = (url: string, body: object, headersOverride: HeadersInit = {}): Request => {
+    const headers = {
+        ...{
             "Content-Type": "application/json"
         },
+        ...headersOverride
+    };
+    return new Request(url, {
+        method: "POST",
+        headers,
         body: JSON.stringify(body)
     });
 };

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"go.larrymyers.com/protoc-gen-twirp_typescript/generator"
+	"go.larrymyers.com/protoc-gen-twirp_typescript/generator/minimal"
 )
 
 func main() {
@@ -53,6 +54,11 @@ func generate(in *plugin.CodeGeneratorRequest) *plugin.CodeGeneratorResponse {
 		for _, cf := range files {
 			resp.File = append(resp.File, cf)
 		}
+	}
+
+	lib, _ := params["library"]
+	if lib != "pbjs" {
+		resp.File = append(resp.File, minimal.RuntimeLibrary())
 	}
 
 	return resp


### PR DESCRIPTION
I know you are not keen on making the simple JSON client more robust - however native mobile app frameworks do not support POSTing binary via HTTP client, so I'm backed into a corner (can't use protobuf client).

This PR:

- Allows Fetch header overrides in a safe and backwards compatible manor
- In proto3, all fields are [optional](https://stackoverflow.com/questions/31801257/why-required-and-optional-is-removed-in-protocol-buffers-3).  Implemented backwards compat change allowing this.
- Support for generic empty messages (very [common](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/empty.proto)).  
- Generated service.ts code formatting cleanup (remove un-tidy whitespace, sorry OCD :)