### PR TITLE
Fix decode an error reponse logic

### DIFF
--- a/pbjs-twirp/twirp.ts
+++ b/pbjs-twirp/twirp.ts
@@ -21,7 +21,7 @@ const getTwirpError = (err: AxiosError): TwirpError => {
             let s = data.toString();
 
             if (s === "[object ArrayBuffer]") {
-                s = String.fromCharCode.apply(null, new Uint8Array(data));
+                s = new TextDecoder("utf-8").decode(new Uint8Array(data));
             }
 
             try {


### PR DESCRIPTION
Hello. I faced an error when a server returns an error contains Non Ascii message like this.

```go
func (s *serv) F(context.Context, *empty.Empty) (*empty.Empty, error) {
        _, err := func()
	if err != nil {
		return nil, twirp.NewError(twirp.InvalidArgument, 
                      "これはエラーです/這是一個錯誤") // Not ascii message
	}
}
```
When above server returns the error, the message is garbled as follows.
```
Error: ã·ã¼ã¯ã¬ããã³ã¼ããå­å¨ãã¾ãã
    at eval (twirp.js?27db:44)
twirp.js?27db:44 Uncaught (in promise) Error: ã·ã¼ã¯ã¬ããã³ã¼ããå­å¨ãã¾ãã
    at eval (twirp.js?27db:44)
``` 

And I recommend using `new TextDecoder("utf-8")` instead of `String.fromCharCode`
```
String.fromCharCode.apply(null, new Uint8Array([123,34,99,111,100,101,34,58,34,105,110,118,97,108,105,100,95,97,114,103,117,109,101,110,116,34,44,34,109,115,103,34,58,34,-29,-127,-109,-29,-126,-116,-29,-127,-81,-29,-126,-88,-29,-125,-87,-29,-125,-68,-29,-127,-89,-29,-127,-103,47,-23,-128,-103,-26,-104,-81,-28,-72,-128,-27,-128,-117,-23,-116,-81,-24,-86,-92,34,125]));
"{"code":"invalid_argument","msg":"ããã¯ã¨ã©ã¼ã§ã/éæ¯ä¸åé¯èª¤"}"
new TextDecoder("utf-8").decode( new Uint8Array([123,34,99,111,100,101,34,58,34,105,110,118,97,108,105,100,95,97,114,103,117,109,101,110,116,34,44,34,109,115,103,34,58,34,-29,-127,-109,-29,-126,-116,-29,-127,-81,-29,-126,-88,-29,-125,-87,-29,-125,-68,-29,-127,-89,-29,-127,-103,47,-23,-128,-103,-26,-104,-81,-28,-72,-128,-27,-128,-117,-23,-116,-81,-24,-86,-92,34,125]));
"{"code":"invalid_argument","msg":"これはエラーです/這是一個錯誤"}"
```

Most sincerely.