### PR TITLE
feature:Return TwirpError Object

### DIFF
--- a/pbjs-twirp/twirp.ts
+++ b/pbjs-twirp/twirp.ts
@@ -4,7 +4,7 @@ import {Message, Method, rpc, RPCImpl, RPCImplCallback} from 'protobufjs';
 interface TwirpError {
     code: string;
     msg: string;
-    meta:{[key:string]:string};
+    meta?:{[key:string]:string};
 }
 
 const getTwirpError = (err: AxiosError): TwirpError => {
@@ -16,7 +16,6 @@ const getTwirpError = (err: AxiosError): TwirpError => {
     };
 
     if (resp) {
-        console.warn(resp)
         const headers = resp.headers;
         const data = resp.data;
 
@@ -56,7 +55,7 @@ export const createTwirpAdapter = (axios: AxiosInstance, methodLookup: (fn: any)
 
         })
         .catch((err: AxiosError) => {
-            callback(new Error(getTwirpError(err).msg), null);
+            callback(getTwirpError(err), null);
         });
     };
 };

--- a/pbjs-twirp/twirp.ts
+++ b/pbjs-twirp/twirp.ts
@@ -4,16 +4,19 @@ import {Message, Method, rpc, RPCImpl, RPCImplCallback} from 'protobufjs';
 interface TwirpError {
     code: string;
     msg: string;
+    meta:{[key:string]:string};
 }
 
 const getTwirpError = (err: AxiosError): TwirpError => {
     const resp = err.response;
     let twirpError = {
         code: 'unknown',
-        msg: 'unknown error'
+        msg: 'unknown error',
+        meta: {}
     };
 
     if (resp) {
+        console.warn(resp)
         const headers = resp.headers;
         const data = resp.data;
 


### PR DESCRIPTION
Since only the message of TwirpError was returned when an error occurred, meta information of Twirp could not be obtained.
Therefore, we have made it possible to return TwirpErrorObject, so please check it.