### PR TITLE
Update axios version for pbjs-twirp package

### DIFF
--- a/example/pbjs_client/package.json
+++ b/example/pbjs_client/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.19.0",
     "pbjs-twirp": "^0.0.1",
     "protobufjs": "^6.8.8",
     "typescript": "^3.1.3"

--- a/pbjs-twirp/package.json
+++ b/pbjs-twirp/package.json
@@ -9,7 +9,7 @@
   "author": "Larry Myers <larry@larrymyers.com>",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.19.0",
     "protobufjs": "^6.8.8"
   }
 }


### PR DESCRIPTION
`pbjs-twirp` uses `axios` at version `^0.18.0` that has incompatible typings with the current `0.19.2` version. This forces library consumers to use `0.18.1` but `0.19.0` has been published 2 years ago and it seems that it's time to upgrade `axios` version.

I've looked through `axios`'s release notes and didn't find any breaking changes that could possibly break the lib. Also, I've tried `axios` `0.19.2` with generator and everything seems fine. So, I think it's safe to move to the current stable `axios` version.