### PR TITLE
fix: use also float definition for Ts number representation

### DIFF
--- a/generator/minimal/client.go
+++ b/generator/minimal/client.go
@@ -381,6 +381,7 @@ func protoToTSType(f *descriptor.FieldDescriptorProto) (string, string) {
 
 	switch f.GetType() {
 	case descriptor.FieldDescriptorProto_TYPE_DOUBLE,
+		descriptor.FieldDescriptorProto_TYPE_FLOAT,
 		descriptor.FieldDescriptorProto_TYPE_FIXED32,
 		descriptor.FieldDescriptorProto_TYPE_FIXED64,
 		descriptor.FieldDescriptorProto_TYPE_INT32,


### PR DESCRIPTION
I just notices while playing around, that the float were typescript strings. 