### PR TITLE
fix: Fix a case where content-type was not judged correctly in error processing

### DIFF
--- a/pbjs-twirp/twirp.ts
+++ b/pbjs-twirp/twirp.ts
@@ -19,7 +19,7 @@ const getTwirpError = (err: AxiosError): TwirpError => {
         const headers = resp.headers;
         const data = resp.data;
 
-        if (headers['content-type'] === 'application/json') {
+        if (/application\/json/.test(headers['content-type'])) {
             let s = data.toString();
 
             if (s === "[object ArrayBuffer]") {


### PR DESCRIPTION
Fix a bug where `Content-Type` is not judged correctly.
The `Content-Type` often contains a `charset` like `application/json; charset=UTF-8`, maybe in cultures that use multi-byte strings.
