### PR TITLE
Bump pbjs-twirp dependencies

### DIFF
--- a/pbjs-twirp/package.json
+++ b/pbjs-twirp/package.json
@@ -9,7 +9,7 @@
   "author": "Larry Myers <larry@larrymyers.com>",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.19.0",
-    "protobufjs": "^6.8.8"
+    "axios": "^0.21.1",
+    "protobufjs": "^6.10.2"
   }
 }

--- a/pbjs-twirp/package.json
+++ b/pbjs-twirp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbjs-twirp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "the runtime library for protoc-gen-twirp_typescript",
   "main": "dist/twirp.js",
   "scripts": {


### PR DESCRIPTION
We're receiving Dependabot PRs to bump axios in our repo, which we can't merge because we also depend on this library. It'd be great if we could bump these deps so they're up-to-date.