### PR TITLE
add support for enum in a message

### DIFF
--- a/generator/minimal/client.go
+++ b/generator/minimal/client.go
@@ -296,6 +296,7 @@ func (g *Generator) Generate(d *descriptor.FileDescriptorProto) ([]*plugin.CodeG
 			model.Fields = append(model.Fields, newField(f))
 		}
 
+		ctx.Enums = append(ctx.Enums, extractEnums(m.GetEnumType())...)
 		ctx.AddModel(model)
 	}
 
@@ -326,19 +327,7 @@ func (g *Generator) Generate(d *descriptor.FileDescriptorProto) ([]*plugin.CodeG
 		ctx.Services = append(ctx.Services, service)
 	}
 
-	for _, e := range d.GetEnumType() {
-		options := make([]EnumOption, 0)
-		for _, x := range e.GetValue() {
-			options = append(options, EnumOption{
-				Key:   x.GetName(),
-				Value: x.GetNumber(),
-			})
-		}
-		ctx.Enums = append(ctx.Enums, &Enum{
-			Name:   e.GetName(),
-			Options: options,
-		})
-	}
+	ctx.Enums = append(ctx.Enums, extractEnums(d.GetEnumType())...)
 
 	// Only include the custom 'ToJSON' and 'JSONTo' methods in generated code
 	// if the Model is part of an rpc method input arg or return type.
@@ -557,4 +546,22 @@ func parse(f ModelField, modelName string) string {
 	}
 
 	return field
+}
+
+func extractEnums(d []*descriptor.EnumDescriptorProto) []*Enum {
+	enums := make([]*Enum, 0)
+	for _, e := range d {
+		options := make([]EnumOption, 0)
+		for _, x := range e.GetValue() {
+			options = append(options, EnumOption{
+				Key:   x.GetName(),
+				Value: x.GetNumber(),
+			})
+		}
+		enums = append(enums, &Enum{
+			Name:   e.GetName(),
+			Options: options,
+		})
+	}
+	return enums
 }


### PR DESCRIPTION
I noticed that nested messages don't seem to be supported #1

So for now i've changed the goal of this PR to make it such that any .proto prior to #63 that was previously working, should still continue to work

The above caveat is explicit because while
```
message A {
  message B {
    enum C {
      ....
    }
  }
}
```
will not work, it should at the very least not make things worse