### PR TITLE
update axios and protobufjs

### DIFF
--- a/pbjs-twirp/package.json
+++ b/pbjs-twirp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbjs-twirp",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "the runtime library for protoc-gen-twirp_typescript",
   "main": "dist/twirp.js",
   "scripts": {
@@ -9,10 +9,10 @@
   "author": "Larry Myers <larry@larrymyers.com>",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.21.1",
-    "protobufjs": "^6.10.2"
+    "axios": "^0.24.0",
+    "protobufjs": "^6.11.2"
   },
   "devDependencies": {
-    "typescript": "^4.1.3"
+    "typescript": "^4.5.3"
   }
 }


### PR DESCRIPTION
This PR updates `axios` to `0.24.0`, `protobufjs` to `6.11.2`, and typescript to version `4.5.3`. 

We were receiving a dependabot alert and noticed breaking changes when updating axios to this version.
