### PR TITLE
Fix dependencies

### DIFF
--- a/pbjs-twirp/package.json
+++ b/pbjs-twirp/package.json
@@ -8,11 +8,13 @@
   },
   "author": "Larry Myers <larry@larrymyers.com>",
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "axios": "^0.24.0",
     "protobufjs": "^6.11.2"
   },
   "devDependencies": {
+    "axios": "^0.24.0",
+    "protobufjs": "^6.11.2",
     "typescript": "^4.5.3"
   }
 }


### PR DESCRIPTION
Keeping `axios` and `protobufjs` in `dependencies` will lead to 2 versions of each package being installed if consumer app is using different ones from `pbjs-twirp`. And since `axios` changes it's typings without looking at backward compatibility, the type mismatch error will happen, preventing developers from using the library or making them to create workarounds.

To fix this behavior we need to move `axios` and `protobuf` to `peerDependencies` and `devDependecies` so they will be properly availabe for both library developers and consumers.